### PR TITLE
Upgrade vue to 1.0.21 and vue-router to 0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lodash": "^3.10.1",
     "moment": "^2.10.6",
     "nvd3": "^1.8.1",
-    "vue": "^1.0.0-alpha.4",
-    "vue-router": "^0.6.0",
+    "vue": "^1.0.21",
+    "vue-router": "^0.7.13",
     "whatwg-fetch": "^0.9.0"
   },
   "devDependencies": {

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -62,7 +62,7 @@ export default Vue.extend({
     moduleData: Array
   },
   template: `
-    <div $$.chart id="chart" class="with-3d-shadow with-transitions">
+    <div v-el:chart id="chart" class="with-3d-shadow with-transitions">
       <legend v-if="moduleData.length && legendData" bind-modules="legendData.modules" bind-date="legendData.date"></legend>
       <svg></svg>
     </div>
@@ -149,7 +149,7 @@ export default Vue.extend({
     const updateChart = _.debounce(() => {
       svg.call(this.chart);
     }, 50);
-    this.hammerInstance = new Hammer(this.$$.chart);
+    this.hammerInstance = new Hammer(this.$els.chart);
     this.hammerInstance.get('pinch').set({ enable: true });
     this.hammerInstance.on('pinchin', e => {
       const [currentStart, end] = chart.brushExtent().map(x => new Date(x).getTime());

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -2,7 +2,8 @@
   <h1 class="heading">
     <a href="/" class="identity" v-link="{ path: '/'}">npmcharts</a>
     <iframe class="github-btn" src="https://ghbtns.com/github-btn.html?user=cheapsteak&repo=npmcharts.com&type=star" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-    <p class="sub-heading">compare npm packages and spot&nbsp;download&nbsp;trends</p></h1>
+    <p class="sub-heading">compare npm packages and spot&nbsp;download&nbsp;trends</p>
+  </h1>
   <form>
     <package-input class="package-input" bind-on-submit="addPackage"></package-input>
     <div class="graph-config">

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -38,11 +38,11 @@
   <graph
     class="chart"
     v-if="moduleNames"
-    bind-module-names="moduleNames"
-    bind-module-data="moduleData"
-    bind-show-weekends="showWeekends"
-    bind-show-outliers="showOutliers"
-    bind-is-preset="isPreset"
+    :module-names="moduleNames"
+    :module-data="moduleData"
+    :show-weekends="showWeekends"
+    :show-outliers="showOutliers"
+    :is-preset="isPreset"
   >
   </graph>
   <div class="no-packages-selected" v-if="!moduleData">

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -1,6 +1,6 @@
 <header class="page-header">
   <h1 class="heading">
-    <a href="/" class="identity" v-link#="/">npmcharts</a>
+    <a href="/" class="identity" v-link="{ path: '/'}">npmcharts</a>
     <iframe class="github-btn" src="https://ghbtns.com/github-btn.html?user=cheapsteak&repo=npmcharts.com&type=star" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
     <p class="sub-heading">compare npm packages and spot&nbsp;download&nbsp;trends</p></h1>
   <form>

--- a/src/index.jade
+++ b/src/index.jade
@@ -5,7 +5,7 @@ html
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1")
     meta(name="description" content="Chart download stats for npm packages. Compare graphs and spot trends. Try Browserify vs Webpack, Grunt vs Gulp, or React vs Angular vs Ember")
-    link(rel='stylesheet', href='css/style.css')
+    link(rel='stylesheet', href='/css/style.css')
     link(rel="apple-touch-icon", sizes="57x57", href="/apple-touch-icon-57x57.png")
     link(rel="apple-touch-icon", sizes="60x60", href="/apple-touch-icon-60x60.png")
     link(rel="apple-touch-icon", sizes="72x72", href="/apple-touch-icon-72x72.png")

--- a/src/index.jade
+++ b/src/index.jade
@@ -5,7 +5,6 @@ html
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1")
     meta(name="description" content="Chart download stats for npm packages. Compare graphs and spot trends. Try Browserify vs Webpack, Grunt vs Gulp, or React vs Angular vs Ember")
-    link(rel="stylesheet" href="/css/style.css")
     link(rel='stylesheet', href='css/style.css')
     link(rel="apple-touch-icon", sizes="57x57", href="/apple-touch-icon-57x57.png")
     link(rel="apple-touch-icon", sizes="60x60", href="/apple-touch-icon-60x60.png")

--- a/src/packages/packages.js
+++ b/src/packages/packages.js
@@ -21,8 +21,10 @@ export default Vue.extend({
     onSubmit: Function
   },
   template: `
-    <input class="package-input" $$.textbox on-keyup="validate" placeholder="package name">
-    <button class="add-package-btn" bind-disabled="!valid" on-click="submit($$.textbox.value, $event)">add</button>
+    <span>
+      <input class="package-input" $$.textbox on-keyup="validate" placeholder="package name">
+      <button class="add-package-btn" bind-disabled="!valid" on-click="submit($$.textbox.value, $event)">add</button>
+    </span>
   `,
   data () {
     return {


### PR DESCRIPTION
A lot of plugins weren't compatible with the 1.0.0.alpha-4 version previously used
Most importantly, this should allow [vue-typeahead](https://github.com/pespantelis/vue-typeahead) to be used