### PR TITLE
Show github commit stats when package names are github commits

### DIFF
--- a/packages/frontend/src/graph/graph.js
+++ b/packages/frontend/src/graph/graph.js
@@ -256,7 +256,10 @@ export default Vue.extend({
       );
 
       return this.processedData[0].values[
-        this.processedData[0].values.length - startOfPeriodBucket - 1
+        Math.max(
+          0,
+          this.processedData[0].values.length - startOfPeriodBucket - 1,
+        )
       ].day;
     },
     getDataAtDate(date) {

--- a/packages/frontend/src/home/fetchReposCommitStats.js
+++ b/packages/frontend/src/home/fetchReposCommitStats.js
@@ -1,0 +1,30 @@
+import _ from 'lodash';
+import { setDay } from 'date-fns';
+
+export const fetchRepoStats = orgRepo => {
+  const url = `https://api.github.com/repos/${orgRepo}/stats/commit_activity`;
+  return fetch(url)
+    .then(response => response.json())
+    .then(data =>
+      _.flow(
+        dataChunkedByWeek =>
+          dataChunkedByWeek.map(week =>
+            week.days.map((commits, i) => ({
+              count: commits,
+              day: setDay(week.week * 1000, i),
+            })),
+          ),
+        _.flatMap,
+      )(data),
+    );
+};
+
+export const fetchReposStats = orgRepos =>
+  Promise.all(
+    orgRepos.map(async orgRepo => ({
+      downloads: await fetchRepoStats(orgRepo),
+      name: orgRepo,
+    })),
+  );
+
+export default fetchReposStats;

--- a/packages/utils/isPackageName.js
+++ b/packages/utils/isPackageName.js
@@ -1,0 +1,4 @@
+const isScopedPackageName = require('./isScopedPackageName');
+
+module.exports = packageName =>
+  isScopedPackageName(packageName) || !packageName.includes('/');


### PR DESCRIPTION
When github `org/repo`s are provided instead of package names, the chart will show commit activity instead of download counts

http://localhost:9001/compare/Microsoft/vscode,atom/atom

![image](https://user-images.githubusercontent.com/743976/44624098-a6728180-a8b1-11e8-9b64-fe07b51554e1.png)
