### PR TITLE
Fix download from alternative site

### DIFF
--- a/packages/frontend/webpack.config.js
+++ b/packages/frontend/webpack.config.js
@@ -21,6 +21,9 @@ module.exports = {
     contentBase: [path.join(__dirname, 'src/assets')],
     compress: true,
     port: 9001,
+    proxy: {
+      '/api': 'http://localhost:3000'
+    }
   },
   module: {
     rules: [

--- a/packages/utils/stats/fetchPackagesStats.js
+++ b/packages/utils/stats/fetchPackagesStats.js
@@ -2,17 +2,27 @@ const fetch = require('isomorphic-fetch');
 
 module.exports = (packageNames, startDate, endDate) => {
   const packageNamesParam = packageNames.join(',');
-  const url = `https://api.npmjs.org/downloads/range/${startDate}:${endDate}/${packageNamesParam}`;
-  const fallbackUrl = `/api/downloads/range/${startDate}:${endDate}/${packageNamesParam}`;
-  return fetch(url)
-    .then(response => {
-      if (!response.ok) {
-        return fetch(fallbackUrl);
-      }
-      return response.json();
-    })
-    .catch(exception => {
-      console.error(exception);
-      return fetch(fallbackUrl);
-    });
+  const baseUrls = ['https://api.npmjs.org/downloads/range', '/api/downloads/range'];
+
+  function fetchStats() {
+    const baseUrl = baseUrls.shift();
+    if(!baseUrl) {
+      throw new Error('Failed to download chart data.');
+    }
+    const url = `${baseUrl}/${startDate}:${endDate}/${packageNamesParam}`;
+    return fetch(url)
+      .then(response => {
+        if (!response.ok) {
+          return fetch(fallbackUrl);
+        }
+        return response.json();
+      })
+      .catch(err => {
+        console.error(`Failed to download from url=${url}, err: ${err.message}`);
+        return fetchStats(baseUrl); // Try next URL
+      });
+  }
+
+  return fetchStats();
+
 };


### PR DESCRIPTION
Issue #76 

I probably changed more then required.

I simulated the `Uncaught TypeError: Cannot read property 'downloads' of undefined` by using the local dev server as the proxy mirror.

The changes I made in `fetchPackagesStats.js` seem to eliminate error.
I changed a bit more then strictly required, sorry about that.