### PR TITLE
Improve code fetching statistics

### DIFF
--- a/packages/utils/stats/fetchPackagesStats.js
+++ b/packages/utils/stats/fetchPackagesStats.js
@@ -1,25 +1,27 @@
 const fetch = require('isomorphic-fetch');
 
 module.exports = (packageNames, startDate, endDate) => {
+
   const packageNamesParam = packageNames.join(',');
-  const baseUrls = ['https://api.npmjs.org/downloads/range', '/api/downloads/range'];
+  const baseApiUrls = ['https://api.npmjs.org', '/api'];
 
   function fetchStats() {
-    const baseUrl = baseUrls.shift();
+    const baseUrl = baseApiUrls.shift();
     if(!baseUrl) {
       throw new Error('Failed to download chart data.');
     }
-    const url = `${baseUrl}/${startDate}:${endDate}/${packageNamesParam}`;
+    const url = `${baseUrl}/downloads/range/${startDate}:${endDate}/${packageNamesParam}`;
     return fetch(url)
       .then(response => {
         if (!response.ok) {
-          return fetch(fallbackUrl);
+          console.warn(`Unexpected HTTP response from url=${url}: status:${response.status}: "${response.statusText}"`);
+          return fetchStats(); // Try next URL
         }
         return response.json();
       })
       .catch(err => {
-        console.error(`Failed to download from url=${url}, err: ${err.message}`);
-        return fetchStats(baseUrl); // Try next URL
+        console.warn(`Failed to download from url=${url}, err: "${err.message}"`);
+        return fetchStats(); // Try next URL
       });
   }
 


### PR DESCRIPTION
Follow up on issue #76:

- Proper handling in case an unsuccessful HTTP status is returned by the API.
- Log URL failures at warning level
