### PR TITLE
Implemented ability to retrieve charts over different & longer periods

### DIFF
--- a/packages/frontend/src/graph/graph.html
+++ b/packages/frontend/src/graph/graph.html
@@ -2,7 +2,7 @@
   <graphLegend
     v-if="moduleData.length && legendData"
     :modules="legendData.modules"
-    :period-length="periodLength"
+    :interval="interval"
     :date="legendData.date"
     @package-focus="handlePackageFocus"
     @package-blur="handlePackageBlur"

--- a/packages/frontend/src/graph/graph.js
+++ b/packages/frontend/src/graph/graph.js
@@ -17,13 +17,13 @@ const catmulRomInterpolation = (points, tension) =>
     .curve(curveCatmullRom)(points)
     .replace(/^M/, '');
 
-function processEntries(entries, { showWeekends = false, periodLength = 7 }) {
-  if (periodLength !== 1) {
+function processEntries(entries, { showWeekends = false, interval = 7 }) {
+  if (interval !== 1) {
     entries = _.flow([
       entries =>
         _.groupBy(entries, entry =>
           Math.floor(
-            (entries.length - entries.indexOf(entry) - 1) / periodLength,
+            (entries.length - entries.indexOf(entry) - 1) / interval,
           ),
         ),
       _.values,
@@ -63,7 +63,7 @@ export default withRender({
       type: Boolean,
       default: true,
     },
-    periodLength: {
+    interval: {
       type: Number,
       default: 7,
     },
@@ -98,7 +98,7 @@ export default withRender({
     moduleData() {
       this.render();
     },
-    periodLength() {
+    interval() {
       this.render();
     },
   },
@@ -163,9 +163,9 @@ export default withRender({
           module.downloads,
           {
             showWeekends: this.showWeekends,
-            periodLength: this.periodLength,
+            interval: this.interval,
           },
-          [module.name, this.showWeekends, this.periodLength].join(','),
+          [module.name, this.showWeekends, this.interval].join(','),
         ),
       }));
     },
@@ -174,7 +174,7 @@ export default withRender({
       const processedData = this.processForD3(this.moduleData);
       this.processedData = processedData;
       const interpolation =
-        this.periodLength > 1 ? catmulRomInterpolation : 'linear';
+        this.interval > 1 ? catmulRomInterpolation : 'linear';
 
       chart.interpolate(interpolation);
 
@@ -250,7 +250,7 @@ export default withRender({
 
       const startOfPeriodBucket = Math.floor(
         (this.moduleData[0].downloads.length - indexInModuleData) /
-          this.periodLength,
+          this.interval,
       );
 
       return this.processedData[0].values[

--- a/packages/frontend/src/graph/legend/legend.html
+++ b/packages/frontend/src/graph/legend/legend.html
@@ -7,7 +7,7 @@
     </thead>
     <thead class="date" v-else>
       <th class="package-downloads-heading">{{date | formatDate('dddd')}}</th>
-      <th class="package-name-heading">{{date | formatDate('MMMM Do')}}</th>
+      <th class="package-name-heading">{{date | formatDate('MMMM Do, YYYY')}}</th>
     </thead>
     <tbody
       @mouseEnter="handleMouseEnterLegend()"

--- a/packages/frontend/src/graph/legend/legend.html
+++ b/packages/frontend/src/graph/legend/legend.html
@@ -2,7 +2,7 @@
   class="legend"
 >
   <table class="modules">
-    <thead class="date" v-if="periodLength > 1">
+    <thead class="date" v-if="interval > 1">
       <th class="" colspan="2">{{formatWeekByStartingDate(date)}}</th>
     </thead>
     <thead class="date" v-else>

--- a/packages/frontend/src/graph/legend/legend.js
+++ b/packages/frontend/src/graph/legend/legend.js
@@ -7,7 +7,7 @@ export default withRender({
   props: {
     modules: Array,
     date: Date,
-    periodLength: Number,
+    interval: Number,
   },
   computed: {
     sortedModules() {
@@ -41,7 +41,7 @@ export default withRender({
         return `${startDate} - ${endDate}`;
       }
       const endDate = formatDate(
-        addDays(startOfPeriod, this.periodLength - 1),
+        addDays(startOfPeriod, this.interval - 1),
         'MMMM Do',
       );
       return `${startDate} - ${endDate}`;

--- a/packages/frontend/src/graph/legend/legend.js
+++ b/packages/frontend/src/graph/legend/legend.js
@@ -34,7 +34,7 @@ export default withRender({
       this.$emit('package-blur', packageName);
     },
     formatWeekByStartingDate(startOfPeriod) {
-      const startDate = formatDate(startOfPeriod, 'MMMM Do');
+      const startDate = formatDate(startOfPeriod, 'MMMM Do, YYYY');
       const endOfPeriod = addDays(startOfPeriod, 6);
       if (isSameMonth(startOfPeriod, endOfPeriod)) {
         const endDate = formatDate(endOfPeriod, 'Do');

--- a/packages/frontend/src/home/home.html
+++ b/packages/frontend/src/home/home.html
@@ -46,31 +46,31 @@
       <router-link
         tag="label"
         v-if="moduleNames"
-        :to="{ path: '/compare/' + moduleNames.join(','), query: getMergedQueryParams({periodLength: 1})}"
-        @change="track('set periodLength', periodLength)"
+        :to="{ path: '/compare/' + moduleNames.join(','), query: getMergedQueryParams({interval: 1})}"
+        @change="track('set interval', interval)"
       >
-        <input type="radio" :checked="periodLength === 1"> daily
+        <input type="radio" :checked="interval === 1"> daily
       </router-link>
       <router-link
         tag="label"
         v-if="moduleNames"
-        :to="{ path: '/compare/' + moduleNames.join(',') + '?', query: getMergedQueryParams({periodLength: 7})}"
-        @change="track('set periodLength', periodLength)"
+        :to="{ path: '/compare/' + moduleNames.join(',') + '?', query: getMergedQueryParams({interval: 7})}"
+        @change="track('set interval', interval)"
       >
-        <input type="radio" :checked="periodLength === 7"> weekly
+        <input type="radio" :checked="interval === 7"> weekly
       </router-link>
       <router-link
         tag="label"
         v-if="moduleNames"
-        :to="{ path: '/compare/' + moduleNames.join(',') + '?', query: getMergedQueryParams({periodLength: 30})}"
-        @change="track('set periodLength', periodLength)"
+        :to="{ path: '/compare/' + moduleNames.join(',') + '?', query: getMergedQueryParams({interval: 30})}"
+        @change="track('set interval', interval)"
       >
-        <input type="radio" :checked="periodLength === 30"> monthly
+        <input type="radio" :checked="interval === 30"> monthly
       </router-link>
       <router-link
         tag="button"
         class="minimal-mode"
-        :to="{ query: { minimal: 'true', periodLength: periodLength }}"
+        :to="{ query: { minimal: 'true', interval: interval }}"
         @click="track('enter-minimal-mode')"
       >enter minimal mode</router-link>
 
@@ -119,7 +119,7 @@
       :module-names="moduleNames"
       :module-data="moduleData"
       :show-weekends="showWeekends"
-      :period-length="periodLength"
+      :period-length="interval"
       :is-minimal-mode="isMinimalMode === 'true'"
     >
     </graph>

--- a/packages/frontend/src/home/home.js
+++ b/packages/frontend/src/home/home.js
@@ -20,7 +20,7 @@ const {
   packages,
 } = require('../packages/packages');
 
-const getModuleDataByNames = async names => {
+const getModuleDataByNames = async (names, start, end) => {
   setTimeout(() => ga('send', 'pageview'));
 
   // set notify to false to prevent triggering route change
@@ -28,7 +28,7 @@ const getModuleDataByNames = async names => {
 
   const operation = _.every(names, isPackageName)
     ? // names are npm packages
-      getPackagesDownloadsOverPeriod(names, 2 * maxRequestPeriod, 0)
+      getPackagesDownloadsOverPeriod(names, start, end)
         .then(processPackagesStats)
     : // names are github repo names
       fetchReposCommitsStats(names);
@@ -85,10 +85,13 @@ function getPackagesDownloadsOverPeriod(names, startDay, endDay) {
 export default withRender({
   created() {
     this.isLoading = true;
-    getModuleDataByNames(this.moduleNames).then(moduleData => {
-      this.isLoading = false;
-      this.moduleData = moduleData;
-    });
+    getModuleDataByNames(this.moduleNames,
+        this.$route.query.start ? this.$route.query.start : 365,
+        this.$route.query.end ? this.$route.query.start : 0)
+      .then(moduleData => {
+        this.isLoading = false;
+        this.moduleData = moduleData;
+      });
   },
   render: withRender.default,
   data() {

--- a/packages/frontend/src/home/home.js
+++ b/packages/frontend/src/home/home.js
@@ -74,7 +74,6 @@ function getPackagesDownloadsOverPeriod(names, startDay, endDay) {
   const requestEndDay = startDay - requestPeriod;
 
   const startStats = new Date(Date.UTC(2015, 1, 10));
-  console.log(`start stats: ${startStats}`)
 
   const DATE_FORMAT = 'YYYY-MM-DD';
   const timezone = 'UTC';

--- a/packages/frontend/src/home/home.js
+++ b/packages/frontend/src/home/home.js
@@ -58,6 +58,10 @@ function mergePeriods(period0, period1) {
   return sumPackages;
 }
 
+function maxDate(a, b) {
+  return new Date(Math.max(a.getTime(), b.getTime()));
+}
+
 /**
  * @param names    {string} Package names
  * @param startDay {number} Start of period, 1 is yesterday
@@ -69,9 +73,17 @@ function getPackagesDownloadsOverPeriod(names, startDay, endDay) {
   const requestPeriod = Math.min(maxRequestPeriod, startDay - endDay);
   const requestEndDay = startDay - requestPeriod;
 
+  const startStats = new Date(Date.UTC(2015, 1, 10));
+  console.log(`start stats: ${startStats}`)
+
   const DATE_FORMAT = 'YYYY-MM-DD';
-  const startDate = formatDate(subDays(new Date(), startDay), DATE_FORMAT);
-  const endDate = formatDate(subDays(new Date(), requestEndDay), DATE_FORMAT);
+  const timezone = 'UTC';
+
+  let startDate = maxDate(startStats, subDays(new Date(), startDay));
+  let endDate = maxDate(startStats, subDays(new Date(), requestEndDay));
+
+  startDate = formatDate(startDate, DATE_FORMAT, null, timezone);
+  endDate = formatDate(endDate, DATE_FORMAT, null, timezone);
 
   const period1 = getPackagesDownloads(names, {startDate, endDate,});
 

--- a/packages/frontend/src/home/home.js
+++ b/packages/frontend/src/home/home.js
@@ -130,8 +130,8 @@ export default withRender({
     queryString() {
       return querystring.stringify(this.$route.query);
     },
-    periodLength() {
-      return Number(this.$route.query.periodLength || 7);
+    interval() {
+      return Number(this.$route.query.interval || this.$route.query.periodLength || 7);
     },
     isUsingPresetPackages() {
       return !this.$route.params.packages;
@@ -179,7 +179,9 @@ export default withRender({
       ga('send', 'event', eventName, value);
     },
     getMergedQueryParams(params) {
-      return { ...this.$route.query, ...params };
+      const merged = { ...this.$route.query, ...params };
+      delete merged.periodLength;
+      return merged;
     },
     handlePackagesChange() {
       const nextRouteSansQuery = `/compare/${packages.join(',')}`;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "dev": "DEBUG=server:* nodemon --exec npm start"
+    "dev": "cross-env DEBUG=server:* nodemon --exec npm start"
   },
   "dependencies": {
     "body-parser": "~1.17.1",
@@ -20,6 +20,7 @@
     "serve-favicon": "~2.4.2"
   },
   "devDependencies": {
+    "cross-env": "5.2.0",
     "nodemon": "^1.11.0"
   }
 }

--- a/packages/utils/stats/getPackagesDownloadsComparisons.js
+++ b/packages/utils/stats/getPackagesDownloadsComparisons.js
@@ -5,18 +5,18 @@ const getPackagesDownloads = require('./getPackagesDownloads');
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
-const getDownloadComparisonForPeriod = (downloads, periodLengthInDays) => {
+const getDownloadComparisonForPeriod = (downloads, intervalInDays) => {
   const trimmedDownloads =
     _.last(downloads).downloads === 0 ? _.initial(downloads) : downloads;
 
   const currentPeriodDownloads = _.sumBy(
-    trimmedDownloads.slice(-periodLengthInDays),
+    trimmedDownloads.slice(-intervalInDays),
     x => x.downloads,
   );
   const previousPeriodDownloads = _.sumBy(
     _.difference(
-      trimmedDownloads.slice(-periodLengthInDays * 2),
-      trimmedDownloads.slice(-periodLengthInDays),
+      trimmedDownloads.slice(-intervalInDays * 2),
+      trimmedDownloads.slice(-intervalInDays),
     ),
     x => x.downloads,
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,6 +2442,13 @@ cron@1.2.1:
   dependencies:
     moment-timezone "^0.5.x"
 
+cross-env@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -5040,7 +5047,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 


### PR DESCRIPTION
Implements issue #80

- [x] Recursive downloads to retrieve data over a period longer then one year
- [x] Select period via URL query
- [x] Rename periodLength to interval
- [x] Don't query before 2015-01-10
- [x] Query in npmjs API in UTC
 