### PR TITLE
Make fetch a bit more error prone

### DIFF
--- a/packages/frontend/src/home/fetchReposCommitStats.js
+++ b/packages/frontend/src/home/fetchReposCommitStats.js
@@ -1,28 +1,28 @@
 import _ from 'lodash';
 import { setDay } from 'date-fns';
 
-export const fetchRepoStats = orgRepo => {
+export async function fetchRepoStats(orgRepo) {
   const url = `https://api.github.com/repos/${orgRepo}/stats/commit_activity`;
-  return fetch(url)
-    .then(response => response.json())
-    .then(data =>
-      _.flow(
-        dataChunkedByWeek =>
-          dataChunkedByWeek.map(week =>
-            week.days.map((commits, i) => ({
-              count: commits,
-              day: setDay(week.week * 1000, i),
-            })),
-          ),
-        _.flatMap,
-      )(data),
-    );
-};
+  const response = await fetch(url);
+  if (response.ok) {
+    const data = response.json();
+    _.flow(
+      dataChunkedByWeek =>
+        dataChunkedByWeek.map(week =>
+          week.days.map((commits, i) => ({
+            count: commits,
+            day: setDay(week.week * 1000, i),
+          })),
+        ),
+      _.flatMap,
+    )(data);
+  }
+}
 
 export const fetchReposStats = orgRepos =>
   Promise.all(
     orgRepos.map(async orgRepo => ({
-      downloads: await fetchRepoStats(orgRepo),
+      downloads: () => fetchRepoStats(orgRepo),
       name: orgRepo,
     })),
   );


### PR DESCRIPTION
Makes the fetching data function a little bit more resistant against an issue with an individual chart: 

If one the package names is wrong, or of there is no data yet available (on the day of the release), still shows the others.