### PR TITLE
Passes query parameter to ogImage

### DIFF
--- a/packages/server/routes/index.js
+++ b/packages/server/routes/index.js
@@ -22,7 +22,9 @@ const sendSPA = async function(req, res, next) {
   );
   const minimalModeUrl = getMinimalUrl(fullUrl.href);
   const ogImage = shouldScreencapUrl(minimalModeUrl)
-    ? `${protocol}://${req.get('host')}/chart-image/${packages.join(',')}.png`
+    ? `${protocol}://${req.get('host')}/chart-image/${packages.join(',')}.png${
+        fullUrl.search ? fullUrl.search : ''
+      }`
     : 'https://npmcharts.com/images/og-image-3.png';
   const pageDescription = await getPackagesDownloadsDescriptions(packages);
 


### PR DESCRIPTION
Fixes #97

-----

# Self-testing

Visit `http://localhost:3896/compare/styled-components,@emotion/core,jss,emotion,tailwindcss?start=100&interval=7` and inspect the `<head>` content:

![Screenshot 2020-10-06 230908](https://user-images.githubusercontent.com/3090380/95220727-581e6380-0829-11eb-9388-c0f052f2639d.png)

As expected, the query parameter  `?start=100&interval=7` is passed through to the `og:image`

----

Visit `http://localhost:3896/compare/styled-components,@emotion/core,jss,emotion,tailwindcss` and inspect the `<head>` content:

![Screenshot 2020-10-06 230852](https://user-images.githubusercontent.com/3090380/95220722-56ed3680-0829-11eb-9e70-fe0822108448.png)

As expected, no query parameter is passed through to the `og:image`

----

Let me know if I miss anything. Thanks!
