### PR TITLE
Investigation (and fix) for log scale issues n charts with Terser's mangle: true

### DIFF
--- a/packages/frontend/src/graph/chart/line.js
+++ b/packages/frontend/src/graph/chart/line.js
@@ -26,11 +26,13 @@ export const line = function() {
       , interpolate = "linear" // controls the line interpolation
       , duration = 250
       , dispatch = d3.dispatch('elementClick', 'elementMouseover', 'elementMouseout', 'renderEnd')
+      , useLogScale = false
       ;
 
   scatter
       .pointSize(16) // default size
       .pointDomain([16,256]) //set to speed up calculation, needs to be unset if there is a custom size accessor
+      .useLogScale(useLogScale) // Passes along configuration for whether log scale is being used for chart
   ;
 
   //============================================================
@@ -188,6 +190,10 @@ export const line = function() {
       color:  {get: function(){return color;}, set: function(_){
           color = nv.utils.getColor(_);
           scatter.color(color);
+      }},
+      useLogScale: {get: function(){return useLogScale;}, set: function(_){
+          useLogScale = _;
+          scatter.useLogScale(_);
       }}
   });
 

--- a/packages/frontend/src/graph/chart/lineChart.js
+++ b/packages/frontend/src/graph/chart/lineChart.js
@@ -26,7 +26,8 @@ export function lineChart() {
     x,
     y,
     dispatch = d3.dispatch('renderEnd'),
-    duration = 250;
+    duration = 250,
+    useLogScale = false;
 
   // set options on sub-objects for this chart
   xAxis.orient('bottom').tickPadding(7);
@@ -35,6 +36,7 @@ export function lineChart() {
   lines.clipEdge(true);
   lines.x(xAccessor);
   lines.y(yAccessor);
+  lines.useLogScale(useLogScale);
 
   //============================================================
   // Private Variables

--- a/packages/frontend/src/graph/chart/scatter.js
+++ b/packages/frontend/src/graph/chart/scatter.js
@@ -39,6 +39,7 @@ export const scatter = function() {
       , dispatch     = d3.dispatch('elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout', 'renderEnd')
       , duration     = 250
       , interactiveUpdateDelay = 300
+      , useLogScale = false
       ;
 
 
@@ -94,7 +95,6 @@ export const scatter = function() {
           });
 
           // Setup Scales
-          var logScale = chart.yScale().toString().includes('log(x)')
           // remap and flatten the data for use in calculating the scales' domains
           var seriesData = (xDomain && yDomain && sizeDomain) ? [] : // if we know xDomain and yDomain and sizeDomain, no need to calculate.... if Size is constant remember to set sizeDomain to speed up performance
               d3.merge(
@@ -112,7 +112,7 @@ export const scatter = function() {
 
            var min = d3.min(seriesData.map(d => d.y || null));
            var max = d3.max(seriesData.map(d => d.y));
-           if (logScale) {
+           if (useLogScale) {
                   y.clamp(true)
                       .domain(yDomain || [min || 0, max * 1.01])
                       .range(yRange || [availableHeight, 0]);
@@ -370,6 +370,7 @@ export const scatter = function() {
       clipRadius:   {get: function(){return clipRadius;}, set: function(_){clipRadius=_;}},
       id:           {get: function(){return id;}, set: function(_){id=_;}},
       interactiveUpdateDelay: {get:function(){return interactiveUpdateDelay;}, set: function(_){interactiveUpdateDelay=_;}},
+      useLogScale:  {get: function(){return useLogScale;}, set: function(_){useLogScale = _;}},
 
       // simple functor options
       x:     {get: function(){return getX;}, set: function(_){getX = d3.functor(_);}},

--- a/packages/frontend/src/graph/graph.js
+++ b/packages/frontend/src/graph/graph.js
@@ -83,6 +83,7 @@ export default withRender({
   watch: {
     useLogScale(val) {
       this.chart.yScale(val ? d3.scale.log() : d3.scale.linear());
+      this.chart.useLogScale(val);
       this.chart.update();
     },
     packageDownloadStats() {
@@ -162,6 +163,7 @@ export default withRender({
       chart.interpolate(interpolation);
 
       chart.yScale(this.useLogScale ? d3.scale.log() : d3.scale.linear());
+      chart.useLogScale(this.useLogScale);
       svg.data([processedData]).call(chart);
 
       this.legendData = this.getDataAtDate(this.chart.xAxis.domain()[1]);


### PR DESCRIPTION
Investigated root cause of charts having funky plot points when `log scale` was checked off on the FE. Closes #124.

## Root Cause

In `packages/frontend/src/graph/chart/scatter.js`, this variable is created:

```javascript
var logScale = chart.yScale().toString().includes('log(x)')
```

And when TersePlugin has `mangled: true`, this function if minified and `log(x)` is no longer present in `chart.yScale().toString()`.

## Proposed Fix (for PR)

Added appropriate getters/setters for `useLogScale` in `lineChart.js`, `line.js`, and `scatter.js` in order to pass down the configuration set in `graph.js`. Happy to discuss implementation style + prettify the files (as they are kinda all over on formatting) so let me know.

**NOTE:** Did not set `mangled: true` for this PR, as that can be done later, but also happy to add it to this PR to save time!

### Before

![Screen Shot 2020-10-06 at 2 42 31 PM](https://user-images.githubusercontent.com/82186/95246609-ba07aa80-07e2-11eb-8411-998479290cc9.png)

### After

![Screen Shot 2020-10-06 at 2 38 11 PM](https://user-images.githubusercontent.com/82186/95246624-bf64f500-07e2-11eb-8965-85895efa999a.png)
