### PR TITLE
Adding fetch for package bundle size, using bundlephobia

### DIFF
--- a/packages/frontend/src/home/fetchBundlesSizes.js
+++ b/packages/frontend/src/home/fetchBundlesSizes.js
@@ -1,0 +1,30 @@
+async function fetchBundleSize(pkgName) {
+  const url = `https://bundlephobia.com/api/size?package=${pkgName}`;
+  const resp = await fetch(url);
+
+  if (resp.ok) {
+    const data = await resp.json();
+    const parse = input => parseFloat(input).toFixed(1);
+    const format = input => input > 1048576
+      ? `${parse(input / 1048576)} MB` : input > 1024
+        ? `${parse(input / 1024)} KB` : `${input} B`;
+
+    return {
+      gzip: format(data.gzip),
+      size: format(data.size),
+    }
+  }
+};
+
+export const fetchBundlesSizes = pkgNames => {
+  return pkgNames.reduce((acc, pkgName) => {
+    fetchBundleSize(pkgName)
+      .then(bundle => {
+        if (bundle) acc[pkgName] = bundle;
+      });
+    return acc
+  }, {});
+}
+
+
+export default fetchBundlesSizes;

--- a/packages/frontend/src/home/home.html
+++ b/packages/frontend/src/home/home.html
@@ -42,7 +42,12 @@
             v-bind:title="'Open ' + moduleName + '\'s npm page'"
             :href="'https://www.npmjs.com/package/'+moduleName"
             target="_blank"
-          >{{ moduleName }}</a>
+          >
+          {{ moduleName }}
+          <template v-if="packagesBundleSizesResponse && packagesBundleSizesResponse[moduleName]">
+            <small>({{ packagesBundleSizesResponse[moduleName]["gzip"] }} gzipped)</small>
+          </template>
+          </a>
           download trends
         </template>
       </p>

--- a/packages/frontend/src/home/home.html
+++ b/packages/frontend/src/home/home.html
@@ -44,11 +44,10 @@
             target="_blank"
           >
           {{ moduleName }}
-          <template v-if="packagesBundleSizesResponse && packagesBundleSizesResponse[moduleName]">
-            <small>({{ packagesBundleSizesResponse[moduleName]["gzip"] }} gzipped)</small>
-          </template>
+          <small v-if="packagesBundleSizesResponse && packagesBundleSizesResponse[moduleName]">
+            ({{ packagesBundleSizesResponse[moduleName]["gzip"] }} gzipped)
+          </small>
           </a>
-          download trends
         </template>
       </p>
 

--- a/packages/frontend/src/home/home.js
+++ b/packages/frontend/src/home/home.js
@@ -7,6 +7,7 @@ import { processPackagesStats } from 'frontend/src/utils/processPackagesStats';
 import getPackagesDownloads from 'utils/stats/getPackagesDownloads';
 import isPackageName from 'utils/isPackageName';
 import fetchReposCommitsStats from 'frontend/src/home/fetchReposCommitStats';
+import fetchBundlesSizes from 'frontend/src/home/fetchBundlesSizes';
 import withRender from './home.html';
 import { downloadCsv } from './downloadCsv';
 
@@ -29,9 +30,9 @@ const getPackagesDownloadDataByNames = async (names, start, end) => {
 
   const operation = _.every(names, isPackageName)
     ? // names are npm packages
-      getPackagesDownloadsOverPeriod(names, start, end)
+    getPackagesDownloadsOverPeriod(names, start, end)
     : // names are github repo names
-      fetchReposCommitsStats(names);
+    fetchReposCommitsStats(names);
 
   return operation;
 };
@@ -146,6 +147,10 @@ export default withRender({
         this.isLoadingVersionsDates = false;
       });
     }
+
+    if (this.shouldFetchBundleSizes) {
+      this.packagesBundleSizesResponse = fetchBundlesSizes(this.packageNames);
+    }
   },
   render: withRender.default,
   data() {
@@ -154,9 +159,11 @@ export default withRender({
       samplePreset: [],
       packagesDownloadStatsResponse: null,
       packagesVersionsDatesResponse: null,
+      packagesBundleSizesResponse: null,
       isLoadingDownloadStats: true,
       isLoadingVersionsDates: true,
       shouldShowVersionDates: true,
+      shouldFetchBundleSizes: true,
       palette,
       hoverCount: 0,
       twitterIcon: require('../assets/images/icon-twitter.svg'),
@@ -205,8 +212,8 @@ export default withRender({
       const packageNames = this.isUsingPresetComparisons
         ? _.sample(presetComparisons)
         : this.$route.params.packages
-            .split(',')
-            .map(packageName => window.decodeURIComponent(packageName));
+          .split(',')
+          .map(packageName => window.decodeURIComponent(packageName));
       return packageNames;
     },
     isMinimalMode() {
@@ -264,11 +271,10 @@ export default withRender({
       );
 
       this.$router.push({
-        path: `/compare/${
-          this.$route.params && this.$route.params.packages
-            ? this.$route.params.packages + ',' + packageName
-            : packageName
-        }`,
+        path: `/compare/${this.$route.params && this.$route.params.packages
+          ? this.$route.params.packages + ',' + packageName
+          : packageName
+          }`,
         query: this.$route.query,
       });
     },

--- a/packages/frontend/src/home/home.styl
+++ b/packages/frontend/src/home/home.styl
@@ -287,3 +287,7 @@ footer
     position: absolute
   & + .package-linkout
     margin-left: 0.5em
+  small
+    font-size: 0.7em;
+    font-weight: 500;
+    margin-left: -0.2em;


### PR DESCRIPTION
* Added a new file, `fetchBundlesSizes.js`, that sends a request to the Bundlephobia api endpoint for fetching sizes of packages
* Added conditional section to package names displayed in header, to add bundle size if it exists for package after the package name

![image](https://user-images.githubusercontent.com/82186/95495697-c2402100-096d-11eb-8cc7-395247e9d5e7.png)
(This is with the size data wrapped with `<small>` tags, open for pulling that back!)