### PR TITLE
Prefetch npmjs apis

### DIFF
--- a/packages/server/routes/index.js
+++ b/packages/server/routes/index.js
@@ -10,6 +10,7 @@ const getMinimalUrl = require('utils/getMinimalUrl');
 const shouldScreencapUrl = require('utils/shouldScreencapUrl');
 const getPackagesDownloadsDescriptions = require('utils/stats/getPackagesDownloadsDescription');
 const getPackgesFromUrl = require('utils/getPackagesFromUrl');
+const getPrefetchUrls = require('./prefetchUrls');
 
 // req.protocol is returning 'http' when it shouldn't
 const protocol = 'https';
@@ -26,6 +27,11 @@ const sendSPA = async function(req, res, next) {
         fullUrl.search ? fullUrl.search : ''
       }`
     : 'https://npmcharts.com/images/og-image-3.png';
+
+  const startDate = req.query.start ? req.query.start : 365;
+  const endDate = req.query.end ? req.query.end : 0;
+  const prefetchUrls = getPrefetchUrls(packages, startDate, endDate);
+
   const pageDescription = await getPackagesDownloadsDescriptions(packages);
 
   res.render('index', {
@@ -36,6 +42,7 @@ const sendSPA = async function(req, res, next) {
       format: 'json',
     })}`,
     ogImage,
+    prefetchUrls,
     isEmbed: !!req.query.minimal,
     canonicalUrl: `https://npmcharts.com${fullUrl.pathname}`,
     jsBundleSrc:

--- a/packages/server/routes/prefetchUrls.js
+++ b/packages/server/routes/prefetchUrls.js
@@ -1,0 +1,22 @@
+const _partition = require('lodash/partition');
+const isScopedPackageName = require('utils/isScopedPackageName');
+const getPackageRequestPeriods = require('utils/getPackageRequestPeriods');
+
+function getPrefetchUrls(packageNames, start, end) {
+  const requestPeriods = getPackageRequestPeriods(start, end);
+
+  // Need to partition into two because npmjs's api does not support retrieving data of scoped and unscoped packages in one request
+  const partitionedPackageNames = _partition(packageNames, isScopedPackageName);
+
+  return partitionedPackageNames
+    .map(packageNames => {
+      return requestPeriods.map(({ startDate, endDate }) => {
+        return `https://api.npmjs.org/downloads/range/${startDate}:${endDate}/${packageNames.join(
+          ',',
+        )}`;
+      });
+    })
+    .flat();
+}
+
+module.exports = getPrefetchUrls;

--- a/packages/server/routes/prefetchUrls.test.js
+++ b/packages/server/routes/prefetchUrls.test.js
@@ -1,0 +1,56 @@
+const getPrefetchUrls = require('./prefetchUrls');
+
+beforeEach(() => {
+  jest.useFakeTimers('modern').setSystemTime(new Date('2020-10-13').getTime());
+});
+
+describe('getPrefetchUrls', () => {
+  const start = 5;
+  const end = 0;
+  function getUrl(packageNames) {
+    return `https://api.npmjs.org/downloads/range/2020-10-08:2020-10-13/${packageNames.join(
+      ',',
+    )}`;
+  }
+  test('all unscoped packages can be grouped into one request', () => {
+    const packageNames = ['package-a', 'package-b', 'package-c'];
+
+    expect(getPrefetchUrls(packageNames, start, end)).toEqual([
+      getUrl(packageNames),
+    ]);
+  });
+  test('all scoped packages need to be separated into one each', () => {
+    const packageNames = [
+      '@group/package-a',
+      '@group/package-b',
+      '@group/package-c',
+    ];
+
+    expect(getPrefetchUrls(packageNames, start, end)).toEqual([
+      getUrl(['@group/package-a']),
+      getUrl(['@group/package-b']),
+      getUrl(['@group/package-c']),
+    ]);
+  });
+  test('mix of unscoped and scoped packages: scoped need to be independent, unscoped can be grouped', () => {
+    const packageNames = [
+      'unscoped-package-a',
+      'unscoped-package-b',
+      'unscoped-package-c',
+      '@group/package-a',
+      '@group/package-b',
+      '@group/package-c',
+    ];
+
+    expect(getPrefetchUrls(packageNames, start, end)).toEqual([
+      getUrl(['@group/package-a']),
+      getUrl(['@group/package-b']),
+      getUrl(['@group/package-c']),
+      getUrl([
+        'unscoped-package-a',
+        'unscoped-package-b',
+        'unscoped-package-c',
+      ]),
+    ]);
+  });
+});

--- a/packages/server/views/index.pug
+++ b/packages/server/views/index.pug
@@ -34,6 +34,8 @@ html(lang="en")
     meta(property="twitter:site" content="@npmcharts")
     meta(property="twitter:image" content=ogImage)
     meta(property="og:image" content=ogImage)
+    each url in prefetchUrls
+      link(rel="prefetch", href=url)
 
     link(rel="manifest", href="/manifest.json")
     if isEmbed

--- a/packages/utils/getPackageRequestPeriods.js
+++ b/packages/utils/getPackageRequestPeriods.js
@@ -1,0 +1,42 @@
+const { format: formatDate, subDays } = require('date-fns');
+
+const maxRequestPeriod = 365; // ~1 year
+
+function maxDate(a, b) {
+  return new Date(Math.max(a.getTime(), b.getTime()));
+}
+
+/**
+ * @param startDay {number} Start of period, 1 is yesterday
+ * @param endDay   {number} End of period 0 is today
+ * @returns {Array<{startDate: string, endDate: string}>}
+ */
+function getPackageRequestPeriods(startDay, endDay) {
+  let requestPeriod;
+  let requestEndDay = 1;
+
+  const startStats = new Date(Date.UTC(2015, 1, 10));
+  let startDate;
+  let endDate;
+
+  const periods = [];
+
+  while (requestEndDay > 0) {
+    requestPeriod = Math.min(maxRequestPeriod, startDay - endDay);
+    requestEndDay = startDay - requestPeriod;
+
+    startDate = maxDate(startStats, subDays(new Date(), startDay));
+    endDate = maxDate(startStats, subDays(new Date(), requestEndDay));
+
+    const period = {
+      startDate: formatDate(startDate, 'YYYY-MM-DD', null, 'UTC'),
+      endDate: formatDate(endDate, 'YYYY-MM-DD', null, 'UTC'),
+    };
+    periods.push(period);
+
+    startDay = startDay - requestPeriod - 1;
+  }
+
+  return periods;
+}
+module.exports = getPackageRequestPeriods;

--- a/packages/utils/getPackageRequestPeriods.test.js
+++ b/packages/utils/getPackageRequestPeriods.test.js
@@ -1,0 +1,39 @@
+const getPackageRequestPeriods = require('./getPackageRequestPeriods');
+
+beforeEach(() => {
+  jest.useFakeTimers('modern').setSystemTime(new Date('2020-10-13').getTime());
+});
+
+test('getPackageRequestPeriods for 1 day', () => {
+  expect(getPackageRequestPeriods(1, 0)).toEqual([
+    {
+      startDate: '2020-10-12',
+      endDate: '2020-10-13',
+    },
+  ]);
+});
+
+test('getPackageRequestPeriods for 100 day', () => {
+  expect(getPackageRequestPeriods(100, 0)).toEqual([
+    {
+      startDate: '2020-07-05',
+      endDate: '2020-10-13',
+    },
+  ]);
+});
+test('getPackageRequestPeriods for 1000 day', () => {
+  expect(getPackageRequestPeriods(1000, 0)).toEqual([
+    {
+      startDate: '2018-01-17',
+      endDate: '2019-01-17',
+    },
+    {
+      startDate: '2019-01-18',
+      endDate: '2020-01-18',
+    },
+    {
+      startDate: '2020-01-19',
+      endDate: '2020-10-13',
+    },
+  ]);
+});


### PR DESCRIPTION
Refactored getting start/end dates to getPackageRequestPeriods

Refactored getPackagesDownloadsOverPeriod to use this new getPackageRequestPeriods

Related to #43

Note that this only prefetches the npmjs's package stats API (`https://api.npmjs.org/downloads/range/${startDate}:${endDate}/${packageNamesParam}`)

![Screenshot 2020-10-13 222347](https://user-images.githubusercontent.com/3090380/95875351-85788d80-0da4-11eb-97c3-402fe9dd3adc.png)



![Screenshot 2020-10-14 220246](https://user-images.githubusercontent.com/3090380/96001872-13b74700-0e6b-11eb-998d-e4f1bf49f3f8.png)
![Screenshot 2020-10-14 220257](https://user-images.githubusercontent.com/3090380/96001883-1619a100-0e6b-11eb-9b3b-ad743a36e63c.png)
![Screenshot 2020-10-14 220329](https://user-images.githubusercontent.com/3090380/96001890-16b23780-0e6b-11eb-9596-5b3f4750d7af.png)
