### PR TITLE
added S to http. http was marked as unsecure.

### DIFF
--- a/packages/frontend/src/home/home.js
+++ b/packages/frontend/src/home/home.js
@@ -204,7 +204,7 @@ export default withRender({
     shareUrl() {
       return (
         this.packageNames &&
-        `http://npmcharts.com/compare/${this.packageNames.join(',')}`
+        `https://npmcharts.com/compare/${this.packageNames.join(',')}`
       );
     },
     twitterShareUrl() {


### PR DESCRIPTION
Saw this issue as a problem in terminal. added httpS to avoid "warning http is unsecure"
would be great in case of a merge you label this as hacktoberfest-accepted
thanks a lot.