### PR TITLE
switch to write node_version to env file

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -38,7 +38,7 @@ jobs:
         node-version: '12.x'
 
     - name: Set node version env var
-      run: echo ::set-env name=NODE_VERSION::$(node --version)
+      run: echo "NODE_VERSION=$(node --version)" >> $GITHUB_ENV
 
     - uses: actions/cache@v1
       id: cache-dependencies


### PR DESCRIPTION
set-env has been deprecated

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files